### PR TITLE
Split dependancies

### DIFF
--- a/multivisor/client/cli.py
+++ b/multivisor/client/cli.py
@@ -2,8 +2,9 @@ from __future__ import absolute_import
 
 import argparse
 
+from . import http
+from . import repl
 from .. import util
-from . import repl, http
 
 
 def parse_args(args=None):

--- a/multivisor/client/http.py
+++ b/multivisor/client/http.py
@@ -1,7 +1,7 @@
 import json
-import time
 
 import louie
+
 import requests
 
 

--- a/multivisor/client/http.py
+++ b/multivisor/client/http.py
@@ -27,13 +27,15 @@ class Multivisor(object):
     @staticmethod
     def _update_status_stats(status):
         supervisors, processes = status['supervisors'], status['processes']
-        s_stats = dict(running=sum((s['running']
-                                    for s in status['supervisors'].itervalues())),
+        s_stats = dict(running=sum(
+            (s['running']
+             for s in status['supervisors'].itervalues())),
                        total=len(supervisors))
         s_stats['stopped'] = s_stats['total'] - s_stats['running']
-        p_stats = dict(running=sum((p['running']
-                                    for p in status['processes'].itervalues())),
-                       total=len(processes))
+        p_stats = dict(
+            running=sum((p['running']
+                         for p in status['processes'].itervalues())),
+            total=len(processes))
         p_stats['stopped'] = p_stats['total'] - p_stats['running']
         stats = dict(supervisors=s_stats, processes=p_stats)
         status['stats'] = stats

--- a/multivisor/client/repl.py
+++ b/multivisor/client/repl.py
@@ -1,21 +1,23 @@
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import re
 import fnmatch
-import datetime
 import functools
 
-import maya
 import louie
-from prompt_toolkit import PromptSession, HTML, print_formatted_text
-from prompt_toolkit.styles import Style
-from prompt_toolkit.history import InMemoryHistory
-from prompt_toolkit.completion import WordCompleter
-from prompt_toolkit.validation import ValidationError
+
+import maya
+
+from prompt_toolkit import HTML
+from prompt_toolkit import PromptSession
+from prompt_toolkit import print_formatted_text
 from prompt_toolkit.application import run_in_terminal
-from prompt_toolkit.key_binding import KeyBindings
 from prompt_toolkit.auto_suggest import AutoSuggestFromHistory
+from prompt_toolkit.completion import WordCompleter
+from prompt_toolkit.history import InMemoryHistory
+from prompt_toolkit.key_binding import KeyBindings
+from prompt_toolkit.styles import Style
+from prompt_toolkit.validation import ValidationError
 
 from . import util
 
@@ -236,4 +238,3 @@ class Repl(object):
                 continue
             except EOFError:
                 break
-

--- a/multivisor/client/repl.py
+++ b/multivisor/client/repl.py
@@ -40,6 +40,7 @@ NOTIF_STYLE = {
   'ERROR': 'red'
 }
 
+
 def process_description(process):
     # TODO
     status = process['statename']
@@ -48,7 +49,8 @@ def process_description(process):
     elif process['running']:
         start = maya.MayaDT(process['start'])
         desc = 'pid {pid}, started {start} ({delta})' \
-               .format(pid=process['pid'], start=start.rfc2822(), delta=start.slang_time())
+               .format(pid=process['pid'], start=start.rfc2822(),
+                       delta=start.slang_time())
     else:
         stop = maya.MayaDT(process['stop'])
         desc = 'stopped on {stop} ({delta} ago)' \
@@ -68,7 +70,9 @@ def process_status(process, max_puid_len=10, group_by='group'):
 
 
 def processes_status(status, group_by='group', filter='*'):
-    filt = lambda p: fnmatch.fnmatch(p['uid'], filter)
+    def filt(p):
+        return fnmatch.fnmatch(p['uid'], filter)
+
     return util.processes_status(status, group_by=group_by, filter=filt,
                                  process_status=process_status)
 
@@ -158,7 +162,7 @@ class Commands(object):
         return getattr(self, method_name)
 
 
-def Prompt(**kwargs):
+def Prompt(**kwargs):  # noqa
     history = InMemoryHistory()
     auto_suggest = AutoSuggestFromHistory()
     prmpt = 'multivisor> '
@@ -206,7 +210,7 @@ class Repl(object):
         self.session.app.invalidate()
 
     @keys.add('f5')
-    def __on_refresh(event):
+    def __on_refresh(event):  # noqa
         run_in_terminal(event.app.commands.refresh_status())
 
     def parse_command_line(self, text):

--- a/multivisor/client/util.py
+++ b/multivisor/client/util.py
@@ -2,15 +2,17 @@ import collections
 
 
 def group_processes_status_by(processes, group_by='group', filter=None):
-    result = collections.defaultdict(lambda : dict(processes={}))
+    result = collections.defaultdict(lambda: dict(processes={}))
     if filter is None:
-        filter = lambda p: True
+        def filter(p):
+            return True
+
     for uid, process in processes.items():
         if not filter(process):
             continue
         name = process[group_by]
         order = result[name]
-        order['name']  = name
+        order['name'] = name
         order['processes'][uid] = process
     return result
 
@@ -33,7 +35,9 @@ def processes_status(status, group_by='process', filter=None,
         puid_len = 8
     result = []
     if filter is None:
-        filter = lambda p: True
+        def filter(p):
+            return True
+
     if group_by in (None, 'process'):
         for puid in sorted(processes):
             process = processes[puid]
@@ -49,4 +53,3 @@ def processes_status(status, group_by='process', filter=None,
                 result.append(process_status(process, max_puid_len=puid_len,
                                              group_by=group_by))
     return result
-

--- a/multivisor/multivisor.py
+++ b/multivisor/multivisor.py
@@ -1,19 +1,22 @@
 #!/usr/bin/env python
-
-import os
-import json
-import time
 import logging
+import time
 import weakref
 from ConfigParser import SafeConfigParser
 
-import louie
-import zerorpc
-from gevent import queue, spawn, sleep, joinall
-from supervisor.xmlrpc import Faults
-from supervisor.states import RUNNING_STATES
+from gevent import joinall
+from gevent import sleep
+from gevent import spawn
 
-from .util import sanitize_url, filter_patterns
+import louie
+
+from supervisor.states import RUNNING_STATES
+from supervisor.xmlrpc import Faults
+
+import zerorpc
+
+from .util import filter_patterns
+from .util import sanitize_url
 
 log = logging.getLogger('multivisor')
 

--- a/multivisor/rpc.py
+++ b/multivisor/rpc.py
@@ -8,25 +8,33 @@ advantages: it avoids creating an eventlistener process just to forward events.
 
 The python environment where supervisor runs must have multivisor installed
 """
-
+import functools
+import logging
 import os
 import queue
-import logging
-import functools
 import threading
 
-from gevent import spawn, hub, sleep
+from gevent import hub
+from gevent import sleep
+from gevent import spawn
 from gevent.queue import Queue
-from zerorpc import stream, Server, LostRemote
 
+
+from supervisor.events import Event
+from supervisor.events import getEventNameByType
+from supervisor.events import subscribe
 from supervisor.http import NOT_DONE_YET
 from supervisor.rpcinterface import SupervisorNamespaceRPCInterface
-from supervisor.events import subscribe, Event, getEventNameByType
 # unsubscribe only appears in supervisor > 3.3.4
 try:
     from supervisor.events import unsubscribe
-except:
-    unsubscribe = lambda x, y: None
+except ImportError:
+    def unsubscribe(*args):
+        pass
+
+from zerorpc import LostRemote
+from zerorpc import Server
+from zerorpc import stream
 
 from .util import sanitize_url
 

--- a/multivisor/rpc.py
+++ b/multivisor/rpc.py
@@ -73,8 +73,8 @@ def sync(klass):
 # prevents supervisor from closing the gevent pipes and 0MQ sockets
 # This is a really agressive move but seems to work until the above
 # bug is solved
-from supervisor.options import ServerOptions
-ServerOptions.cleanup_fds = lambda options : None
+from supervisor.options import ServerOptions  # noqa
+ServerOptions.cleanup_fds = lambda options: None
 
 
 @sync
@@ -122,7 +122,10 @@ class MultivisorNamespaceRPCInterface(SupervisorNamespaceRPCInterface):
             payload_str = str(event)
         payload = dict((x.split(':') for x in payload_str.split()))
         if event_name.startswith('PROCESS_STATE'):
-            pname = "{}:{}".format(payload['groupname'], payload['processname'])
+            pname = "{}:{}".format(
+                payload['groupname'],
+                payload['processname']
+            )
             payload['process'] = self.getProcessInfo(pname)
         # broadcast the event to clients
         server = self.supervisord.options.identifier
@@ -171,7 +174,7 @@ class MultivisorNamespaceRPCInterface(SupervisorNamespaceRPCInterface):
                     self._log.info('stop: closing client')
                     return
                 yield event
-        except LostRemote as e:
+        except LostRemote:
             self._log.info('remote end of stream disconnected')
         finally:
             self._event_channels.remove(channel)
@@ -188,7 +191,7 @@ def start_rpc_server(multivisor, bind):
 
 def run_rpc_server(multivisor, bind, future_server):
     multivisor._log.info('0RPC: spawn server on {}...'.format(os.getpid()))
-    watcher = hub.get_hub().loop.async()
+    watcher = hub.get_hub().loop.async()  # noqa
     stop_event = threading.Event()
     watcher.start(lambda: spawn(multivisor._dispatch_event))
     try:
@@ -213,9 +216,9 @@ def run_rpc_server(multivisor, bind, future_server):
 
 def make_rpc_interface(supervisord, bind=DEFAULT_BIND):
     # Uncomment following lines to configure python standard logging
-    #log_level = logging.INFO
-    #log_fmt = '%(asctime)-15s %(levelname)s %(threadName)-8s %(name)s: %(message)s'
-    #logging.basicConfig(level=log_level, format=log_fmt)
+    # log_level = logging.INFO
+    # log_fmt = '%(asctime)-15s %(levelname)s %(threadName)-8s %(name)s: %(message)s'  # noqa
+    # logging.basicConfig(level=log_level, format=log_fmt)
 
     url = sanitize_url(bind, protocol='tcp', host='*', port=9002)
     multivisor = MultivisorNamespaceRPCInterface(supervisord, url['url'])

--- a/multivisor/server/web.py
+++ b/multivisor/server/web.py
@@ -1,19 +1,25 @@
 #!/usr/bin/env python
-
-import gevent
 from gevent.monkey import patch_all
-patch_all(thread=False)
+patch_all(thread=False)  # noqa
 
+import logging  # noqa
 import os
-import logging
+
+from flask import Flask
+from flask import Response
+from flask import json
+from flask import jsonify
+from flask import render_template
+from flask import request
+
+from gevent import queue
+from gevent import sleep
+from gevent.pywsgi import WSGIServer
 
 import louie
-from gevent import queue, sleep
-from gevent.pywsgi import WSGIServer
-from flask import Flask, render_template, Response, request, json, jsonify
 
-from ..util import sanitize_url
 from ..multivisor import Multivisor
+from ..util import sanitize_url
 
 
 log = logging.getLogger('multivisor')

--- a/multivisor/server/web.py
+++ b/multivisor/server/web.py
@@ -93,7 +93,7 @@ def shutdown_supervisor():
 @app.route("/api/process/restart", methods=['POST'])
 def restart_process():
     patterns = request.form['uid'].split(',')
-    procs = app.multivisor.restart_processes(*patterns)
+    app.multivisor.restart_processes(*patterns)
     return 'OK'
 
 
@@ -132,6 +132,7 @@ def process_log_tail(stream, uid):
         tail = server.tailProcessStdoutLog
     else:
         tail = server.tailProcessStderrLog
+
     def event_stream():
         i, offset, length = 0, 0, 2**12
         while True:
@@ -170,7 +171,7 @@ class Dispatcher(object):
         self.clients.append(client)
 
     def remove_listener(self, client):
-        clients.clients.remove(client)
+        self.clients.remove(client)
 
     def on_multivisor_event(self, signal, payload):
         data = json.dumps(dict(payload=payload, event=signal))
@@ -197,7 +198,10 @@ def main(args=None):
     logging.basicConfig(level=log_level, format=log_fmt)
 
     if not os.path.exists(options.config_file):
-        parser.exit(status=2, message='configuration file does not exist. Bailing out!\n')
+        parser.exit(
+            status=2,
+            message='configuration file does not exist. Bailing out!\n'
+        )
 
     bind = sanitize_url(options.bind, host='0', port=22000)['url']
 

--- a/multivisor/server/zrpc.py
+++ b/multivisor/server/zrpc.py
@@ -1,15 +1,18 @@
-import sys
 import logging
+import sys
 import xmlrpclib
-
-from os import environ
 from functools import partial
+from os import environ
 
 from gevent import spawn
 from gevent.lock import RLock
 from gevent.queue import Queue
-from zerorpc import stream, Server, LostRemote
+
 from supervisor.childutils import getRPCInterface
+
+from zerorpc import LostRemote
+from zerorpc import Server
+from zerorpc import stream
 
 
 READY = 'READY\n'

--- a/multivisor/util.py
+++ b/multivisor/util.py
@@ -1,13 +1,20 @@
 import fnmatch
 import re
+from ConfigParser import SafeConfigParser
 
-_PROTO_RE_STR = '(?P<protocol>\w+)\://'
-_HOST_RE_STR = '?P<host>([\w\-_]+\.)*[\w\-_]+|\*'
-_PORT_RE_STR = '\:(?P<port>\d{1,5})'
+from multivisor import Supervisor
 
-URL_RE = re.compile('({protocol})?({host})?({port})?'.format(protocol=_PROTO_RE_STR,
-                                                             host=_HOST_RE_STR,
-                                                             port=_PORT_RE_STR))
+_PROTO_RE_STR = r'(?P<protocol>\w+)\://'
+_HOST_RE_STR = r'?P<host>([\w\-_]+\.)*[\w\-_]+|\*'
+_PORT_RE_STR = r'\:(?P<port>\d{1,5})'
+
+URL_RE = re.compile(
+    '({protocol})?({host})?({port})?'.format(
+        protocol=_PROTO_RE_STR,
+        host=_HOST_RE_STR,
+        port=_PORT_RE_STR
+    )
+)
 
 
 def sanitize_url(url, protocol=None, host=None, port=None):
@@ -42,7 +49,7 @@ def load_config(config_file):
     supervisors = {}
     config = dict(dft_global, supervisors=supervisors)
     config.update(parser.items('global'))
-    tasks = []
+
     for section in parser.sections():
         if not section.startswith('supervisor:'):
             continue
@@ -50,4 +57,5 @@ def load_config(config_file):
         section_items = dict(parser.items(section))
         url = section_items.get('url', '')
         supervisors[name] = Supervisor(name, url)
+
     return config

--- a/multivisor/util.py
+++ b/multivisor/util.py
@@ -1,5 +1,5 @@
-import re
 import fnmatch
+import re
 
 _PROTO_RE_STR = '(?P<protocol>\w+)\://'
 _HOST_RE_STR = '?P<host>([\w\-_]+\.)*[\w\-_]+|\*'
@@ -51,4 +51,3 @@ def load_config(config_file):
         url = section_items.get('url', '')
         supervisors[name] = Supervisor(name, url)
     return config
-

--- a/multivisor/util.py
+++ b/multivisor/util.py
@@ -1,8 +1,5 @@
 import fnmatch
 import re
-from ConfigParser import SafeConfigParser
-
-from multivisor import Supervisor
 
 _PROTO_RE_STR = r'(?P<protocol>\w+)\://'
 _HOST_RE_STR = r'?P<host>([\w\-_]+\.)*[\w\-_]+|\*'
@@ -39,23 +36,3 @@ def filter_patterns(names, patterns):
     sets = (fnmatch.filter(names, pattern) for pattern in patterns)
     map(result.update, sets)
     return result
-
-
-def load_config(config_file):
-    parser = SafeConfigParser()
-    parser.read(config_file)
-    dft_global = dict(name='multivisor')
-
-    supervisors = {}
-    config = dict(dft_global, supervisors=supervisors)
-    config.update(parser.items('global'))
-
-    for section in parser.sections():
-        if not section.startswith('supervisor:'):
-            continue
-        name = section[len('supervisor:'):]
-        section_items = dict(parser.items(section))
-        url = section_items.get('url', '')
-        supervisors[name] = Supervisor(name, url)
-
-    return config

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
-from setuptools import setup, find_packages
+from setuptools import find_packages
+from setuptools import setup
 
 setup(
     name='multivisor',
@@ -7,11 +8,27 @@ setup(
     author_email='coutinhotiago@gmail.com',
     description='A centralized supervisor UI (web & CLI)',
     packages=find_packages(),
-    package_data={'multivisor.server': ['dist/*',
-                                        'dist/static/css/*',
-                                        'dist/static/js/*']},
-    entry_points=dict(console_scripts=[
-        'multivisor=multivisor.server.web:main',
-        'multivisor-cli=multivisor.client.cli:main']),
-    install_requires=['flask', 'gevent', 'supervisor', 'zerorpc', 'louie',
-                      'maya', 'requests', 'prompt_toolkit>=2.0.0,<2.1.0'])
+    package_data={
+        'multivisor.server': [
+            'dist/*',
+            'dist/static/css/*',
+            'dist/static/js/*'
+        ]
+    },
+    entry_points={
+        'console_scripts': [
+            'multivisor=multivisor.server.web:main',
+            'multivisor-cli=multivisor.client.cli:main'
+        ]
+    },
+    install_requires=[
+        'flask',
+        'gevent',
+        'supervisor',
+        'zerorpc',
+        'louie',
+        'maya',
+        'requests',
+        'prompt_toolkit>=2.0.0,<2.1.0'
+    ]
+)

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,12 @@
 from setuptools import find_packages
 from setuptools import setup
 
+server_requires = [
+    'flask',
+    'gevent',
+    ''
+]
+
 setup(
     name='multivisor',
     version='5.0.2',
@@ -17,14 +23,14 @@ setup(
     },
     entry_points={
         'console_scripts': [
-            'multivisor=multivisor.server.web:main',
-            'multivisor-cli=multivisor.client.cli:main'
+            'multivisor=multivisor.server.web:main [web]',
+            'multivisor-cli=multivisor.client.cli:main [cli]'
         ]
     },
     install_requires=[
         'flask',
         'gevent',
-        'supervisor',
+        'supervisor',  # keep
         'zerorpc',
         'louie',
         'maya',

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,16 @@
 from setuptools import find_packages
 from setuptools import setup
 
-server_requires = [
+web_requires = [
     'flask',
-    'gevent',
-    ''
+    'louie',
+]
+
+client_requires = [
+    'maya',
+    'louie',
+    'requests',
+    'prompt_toolkit>=2.0.0,<2.1.0',
 ]
 
 setup(
@@ -21,20 +27,19 @@ setup(
             'dist/static/js/*'
         ]
     },
+    install_requires=[
+        'gevent',
+        'supervisor',
+        'zerorpc',
+    ],
+    extras_require={
+        'web': web_requires,
+        'cli': client_requires,
+    },
     entry_points={
         'console_scripts': [
             'multivisor=multivisor.server.web:main [web]',
             'multivisor-cli=multivisor.client.cli:main [cli]'
         ]
-    },
-    install_requires=[
-        'flask',
-        'gevent',
-        'supervisor',  # keep
-        'zerorpc',
-        'louie',
-        'maya',
-        'requests',
-        'prompt_toolkit>=2.0.0,<2.1.0'
-    ]
+    }
 )


### PR DESCRIPTION
Split dependencies in setup script + PEP8

By default only the libraries necessary for running the rpc interface are installed.

We can install the cli and the web components via extra_requires.