### PR TITLE
Remove padding from search input.

### DIFF
--- a/src/components/ToolBar.vue
+++ b/src/components/ToolBar.vue
@@ -6,7 +6,7 @@
     <v-spacer></v-spacer>
     <v-text-field append-icon="search" clearable single-line hide-details
                   placeholder="Filter..." v-model="search"
-                  color="grey lighten-1">
+                  color="grey lighten-1" class="no-padding">
     </v-text-field>
     <ActionBar></ActionBar>
     <v-toolbar-items>
@@ -36,3 +36,8 @@ export default {
   }
 }
 </script>
+<style scoped>
+  .no-padding {
+    padding: 0;
+  }
+</style>


### PR DESCRIPTION
In current version search / filter input have a padding-top from vuetify which makes this input not properly aligned vertically with the rest of icons.

![image](https://user-images.githubusercontent.com/10159285/56165087-5b3ce880-5fd2-11e9-9203-ccdd492bb805.png)

This PR fixes this:

![image](https://user-images.githubusercontent.com/10159285/56165111-6b54c800-5fd2-11e9-80fc-6277df2bcc2b.png)

