### PR TITLE
Disable screen when multivisor is offline, show inactive supervisors as disabled

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -3,6 +3,7 @@
     <ToolBar></ToolBar>
     <v-content>
       <v-container fluid grid-list-md>
+        <AlertBar></AlertBar>
         <router-view></router-view>
       </v-container>
     </v-content>
@@ -15,6 +16,7 @@
 <script>
 import ToolBar from '@/components/ToolBar'
 import NotificationBar from '@/components/NotificationBar'
+import AlertBar from '@/components/AlertBar'
 
 import LogSheet from '@/components/process/Log'
 import ProcessDetails from '@/components/process/Details'
@@ -24,7 +26,8 @@ export default {
     ToolBar,
     LogSheet,
     ProcessDetails,
-    NotificationBar
+    NotificationBar,
+    AlertBar
   }
 }
 </script>

--- a/src/components/AlertBar.vue
+++ b/src/components/AlertBar.vue
@@ -1,0 +1,14 @@
+<template>
+    <v-alert :value="error" type="error" transition="scale-transition">{{error}}</v-alert>
+</template>
+
+<script>
+  export default {
+    name: 'AlertBar',
+    computed: {
+      error () {
+        return this.$store.state.error
+      }
+    }
+  }
+</script>

--- a/src/components/supervisor/Card.vue
+++ b/src/components/supervisor/Card.vue
@@ -1,7 +1,7 @@
 <template>
   <v-card>
-    <v-toolbar dense color="indigo" dark>
-      <v-toolbar-title>{{ supervisor.name }}</v-toolbar-title>
+    <v-toolbar dense :color="toolbarColor" dark>
+      <v-toolbar-title>{{ supervisor.name }} <span v-if="inactive">(offline)</span></v-toolbar-title>
       <v-spacer></v-spacer>
 
       <v-tooltip top>
@@ -33,7 +33,7 @@
         <span>Select all</span>
       </v-tooltip>
 
-      <v-menu bottom left>
+      <v-menu v-if="!inactive" bottom left>
         <v-btn icon slot="activator">
           <v-icon>more_vert</v-icon>
         </v-btn>
@@ -62,6 +62,8 @@ export default {
   },
   computed: {
     supervisor () { return this.item.item },
+    inactive () { return !this.supervisor.running },
+    toolbarColor () { return this.inactive ? 'grey lighten-1' : 'indigo' },
     selectedProcesses () {
       let procs = this.$store.state.selectedProcesses.reduce((processes, puid) => {
         let supervisor = puid.split(':', 1)[0]

--- a/src/components/supervisor/Page.vue
+++ b/src/components/supervisor/Page.vue
@@ -37,9 +37,7 @@ export default {
           }
           return groups
         }, {}))
-        if (groups.length) {
-          supervisors.push({...supervisor, groups: groups})
-        }
+        supervisors.push({...supervisor, groups: groups})
         return supervisors
       }, [])
     }

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -23,6 +23,9 @@ const router = new Router({
 router.beforeEach(async function (to, from, next) {
   if (store.state.useAuthentication === undefined || store.state.isAuthenticated === undefined) {
     const response = await fetch('/api/auth')
+    if (response.status === 504) {
+      return next()
+    }
     const data = await response.json()
     store.commit('setUseAuthentication', data.use_authentication)
     store.commit('setIsAuthenticated', data.is_authenticated)

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -7,6 +7,7 @@ Vue.use(Vuex)
 export default new Vuex.Store({
   state: {
     multivisor: multivisor.nullMultivisor,
+    error: '',
     notifications: [],
     selectedProcesses: [],
     search: '',
@@ -70,6 +71,9 @@ export default new Vuex.Store({
     },
     logout (state) {
       state.isAuthenticated = false
+    },
+    setError (state, error) {
+      state.error = error
     }
   },
   actions: {
@@ -77,9 +81,12 @@ export default new Vuex.Store({
       const response = await multivisor.load()
       if (response.status === 401) {
         return
+      } else if (response.status === 504) {  // server down
+        commit('setError', 'Couldn\'t connect to multivisor server, make sure it is running')
+      } else {
+        const data = await response.json()
+        commit('updateMultivisor', data)
       }
-      const data = await response.json()
-      commit('updateMultivisor', data)
       const eventHandler = (event) => {
         if (event.event === 'process_changed') {
           commit('updateProcess', event.payload)


### PR DESCRIPTION
Issue: https://github.com/tiagocoutinho/multivisor/issues/20
Inactive supervisors are displayed as empty cards with grey toolbar:

![image](https://user-images.githubusercontent.com/10159285/57162107-91a99e80-6ded-11e9-93b1-c478220f5274.png)

When multivisor server is not responding there is an error alert. I am not sure if it looks good, let me know what you think.

![image](https://user-images.githubusercontent.com/10159285/57162243-eea55480-6ded-11e9-831d-33445173fa69.png)
