### PR TITLE
Allow to specify password as a SHA-1 hash. Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,24 @@ url=daffyduck.acme.org:9007
 Of course the multivisor itself can be configured in supervisor as a normal
 program.
 
+### Authenthication
+To protect multivisor from unwanted access, you can enable required authentication.
+Specify `username` and `password` parameters in `global` section of your configuration file e.g.:
+```bash
+[global]
+username=test
+password=test
+```
+You can also specify `password` as SHA-1 hash in hex, with `{SHA}` prefix: e.g.
+`{SHA}a94a8fe5ccb19ba61c4c0873d391e987982fbbd3` (example hash is `test` in SHA-1).
+
+In order to use this feature, you also need to set `MULTIVISOR_SECRET_KEY` environmental variable,
+as flask sessions module needs some secret value to create secure session.
+You can generate some random hash easily using python:
+`python -c 'import os; import binascii; print(binascii.hexlify(os.urandom(32)))'`
+
+Remember to restart the server after changes in configuration file.
+
 ## Build & Install
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ url=daffyduck.acme.org:9007
 Of course the multivisor itself can be configured in supervisor as a normal
 program.
 
-### Authenthication
+### Authentication
 To protect multivisor from unwanted access, you can enable required authentication.
 Specify `username` and `password` parameters in `global` section of your configuration file e.g.:
 ```bash
@@ -143,7 +143,7 @@ password=test
 You can also specify `password` as SHA-1 hash in hex, with `{SHA}` prefix: e.g.
 `{SHA}a94a8fe5ccb19ba61c4c0873d391e987982fbbd3` (example hash is `test` in SHA-1).
 
-In order to use this feature, you also need to set `MULTIVISOR_SECRET_KEY` environmental variable,
+In order to use authentication, you also need to set `MULTIVISOR_SECRET_KEY` environmental variable,
 as flask sessions module needs some secret value to create secure session.
 You can generate some random hash easily using python:
 `python -c 'import os; import binascii; print(binascii.hexlify(os.urandom(32)))'`

--- a/multivisor/util.py
+++ b/multivisor/util.py
@@ -80,7 +80,10 @@ def constant_time_compare(val1, val2):
     Taken from Django Source Code
     """
     val1 = hashlib.sha1(val1).hexdigest()
-    val2 = hashlib.sha1(val2).hexdigest()
+    if val2.startswith('{SHA}'):  # password can be specified as SHA-1 hash in config
+        val2 = val2.split('{SHA}')[1]
+    else:
+        val2 = hashlib.sha1(val2).hexdigest()
     if len(val1) != len(val2):
         return False
     result = 0


### PR DESCRIPTION
- Ability to specify password as SHA-1 hash.
- Update documentation with instruction on how to use authentication.