### PR TITLE
Web is not aware when multivisor dies

### DIFF
--- a/src/multivisor.js
+++ b/src/multivisor.js
@@ -38,6 +38,12 @@ export const streamTo = (eventHandler) => {
     let data = JSON.parse(event.data)
     eventHandler(data)
   }
+  eventSource.onerror = () => {
+    eventHandler('error')
+  }
+  eventSource.onclose = () => {
+    eventHandler('close')
+  }
   return eventSource
 }
 

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -74,6 +74,9 @@ export default new Vuex.Store({
     },
     setError (state, error) {
       state.error = error
+    },
+    setMultivisorError (state) {
+      state.error = 'Couldn\'t connect to multivisor server, make sure it is running'
     }
   },
   actions: {
@@ -82,13 +85,16 @@ export default new Vuex.Store({
       if (response.status === 401) {
         return
       } else if (response.status === 504) {  // server down
-        commit('setError', 'Couldn\'t connect to multivisor server, make sure it is running')
+        commit('setMultivisorError')
       } else {
         const data = await response.json()
         commit('updateMultivisor', data)
       }
       const eventHandler = (event) => {
-        if (event.event === 'process_changed') {
+        if (event === 'error' || event === 'close') {
+          commit('setMultivisorError')
+          commit('updateMultivisor', multivisor.nullMultivisor)
+        } else if (event.event === 'process_changed') {
           commit('updateProcess', event.payload)
         } else if (event.event === 'supervisor_changed') {
           commit('updateSupervisor', event.payload)


### PR DESCRIPTION
Handle onerror and onclose in event stream.

I couldn't import store in multivisor.js, if I do `multivisor` is empty object in store. That's why error is set in `eventHandler`.

Issue: https://github.com/tiagocoutinho/multivisor/issues/38