### PR TITLE
Configure continuous integration 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: python
+cache: pip
+
+python:
+  - "2.7"
+  #- "3.3"
+  #- "3.4"
+  #- "3.5"
+  #- "3.6"
+  #- "3.7"
+  
+install:
+  - pip install .
+  - pip install -r requirements-dev.txt
+
+script:
+  # TODO: uncomment isort and flake8 when it will start passing
+  # - isort --check-only
+  # - flake8 --max-line-length=120
+  - pytest

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Multivisor
+[![Build Status](https://travis-ci.org/guy881/multivisor.svg?branch=develop)](https://travis-ci.org/guy881/multivisor)
 
 A centralized supervisor UI (Web & CLI)
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,5 @@
 -r requirements.txt
 pytest==4.4.1
 requests==2.21.0
+isort==4.3.20
+flake8==3.7.7


### PR DESCRIPTION
Issue: https://github.com/tiagocoutinho/multivisor/issues/42

Basic Travis CI configuration. I added `isort` and `flake8`, but it's temporarily commented as it doesn't pass it. I will probably create separate issue for this. Some of those code style issue are solved by PR https://github.com/tiagocoutinho/multivisor/pull/27 .