### PR TITLE
Bring back multivisor rpc event listener

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,16 @@ From within the same python environment as your supervisord process, type:
 pip install multivisor[rpc]
 ```
 
+There are two options to configure multivisor RPC: 1) as an extra
+[rpcinterface](http://supervisord.org/configuration.html#rpcinterface-x-section-settings)
+to supervisord or 2) an [eventlistener](http://supervisord.org/configuration.html#eventlistener-x-section-settings) process managed by supervisord.
+
+The first option has the advantage of not requiring an extra process but it's
+implementation relies on internal supervisord details. Therefore, the multivisor
+author recommends using the 2nd approach.
+
+#### Option 1: rpcinterface
+
 Configure the multivisor rpc interface by adding the following lines
 to your *supervisord.conf*:
 
@@ -64,9 +74,28 @@ If no *bind* is given, it defaults to `*:9002`.
 
 Repeat the above procedure for every supervisor you have running.
 
+#### Option 2: eventlistener
+
+Configure the multivisor rpc interface by adding the following lines
+to your *supervisord.conf*:
+
+```ini
+[eventlistener:multivisor-rpc]
+command=multivisor-rpc --bind 0:9002
+events=PROCESS_STATE,SUPERVISOR_STATE
+```
+
+If no *bind* is given, it defaults to `*:9002`.
+
+You are free to choose the event listener name. As a convention we propose
+`multivisor-rpc`.
+
+Repeat the above procedure for every supervisor you have running.
+
+
 ### Web server
 
-The multivisor webserver requires a python 3.x environment. It must be
+The multivisor web server requires a python 3.x environment. It must be
 installed on a machine with a network access to the different supervisors.
 This is achieved with:
 

--- a/multivisor/multivisor.py
+++ b/multivisor/multivisor.py
@@ -71,7 +71,7 @@ class Supervisor(dict):
             except zerorpc.TimeoutExpired:
                 self.log.info("Timeout expired")
             except Exception as err:
-                self.log.info("Connection error")
+                self.log.warning("Unexpected error %r", err)
             finally:
                 curr_time = time.time()
                 delta = curr_time - last_retry

--- a/multivisor/server/rpc.py
+++ b/multivisor/server/rpc.py
@@ -100,8 +100,9 @@ class Supervisor(object):
                 # probably supervisor is shutting down
                 logging.warn("probably shutting down...")
                 return
-        else:
-            logging.warning("ignored %r", event)
+        elif not name.startswith("SUPERVISOR_STATE"):
+            logging.warning("ignored %s", name)
+            return
         for channel in self.event_channels:
             channel.put(event)
 

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,8 @@ setup(
     entry_points=dict(
         console_scripts=[
             "multivisor=multivisor.server.web:main [web]",
-            "multivisor-cli=multivisor.client.cli:main [cli]",
+            "multivisor-rpc=multivisor.server.rpc:main [rpc]",
+            "multivisor-cli=multivisor.client.cli:main [cli]"
         ]
     ),
     extras_require=extras,


### PR DESCRIPTION
Provide an alternative to multivisor's supervisor RPC extension.

The implementation of multivisor's supervisor RPC extension is complex and prone to problems in the future.

The multivisor RPC uses [zerorpc](http://www.zerorpc.io/) (which in turn uses [gevent](http://www.gevent.org/) and a private implementation [zeromq](https://zeromq.org/) ); supervisor uses a concurrency model based on [asyccore](https://docs.python.org/3/library/asyncore.html). Making the two work together is challenging (to say the least).

Some issues concern me:
* when supervisor restart is called, it closes all file descriptors it has open as part of the cleanup. zeromq doesn't like this at all so a hack is injected in supervisor to prevent it from doing this. This is probably my main concern.
* to make gevent and asyncore work together a OS thread had to be created which handles all zerorpc code. Having a new thread on what was by design a single threaded daemon breaks what I would call supervisor project principles. Also the thread had to be created as daemon thread to be sure supervisor would not hang at shutdown

With this PR I bring back an initial implementation which was to have the multivisor RPC as a supervisor event listener. For me this is the most elegant solution. It was removed because users of the project did not like to see in the GUI a lot of multivisor-rpc processes.
One solution could be to have a filter in `multivisor.conf` so these processes don't show up. If someone has a better solution please let me know.

