### PR TITLE
Fix installation on macOS

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,8 @@
-import sys
+import platform
 from setuptools import setup, find_packages
 
 
-supervisor = "supervisor-win" if "win" in sys.platform else "supervisor"
+supervisor = "supervisor-win" if platform.system() == "Windows" else "supervisor"
 
 extras = {
     "rpc": ["zerorpc", supervisor],


### PR DESCRIPTION
pip install "multivisor[web]==6.0.1" fails on macOS:

```
ERROR: Cannot install multivisor because these package versions have conflicting dependencies.

The conflict is caused by:
    supervisor-win 4.6.0 depends on pywin32==228
    supervisor-win 4.5.0 depends on pywin32==228
    supervisor-win 4.4.0 depends on pywin32
    supervisor-win 4.3.0 depends on pywin32
    supervisor-win 4.2.0 depends on pywin32
    supervisor-win 4.1.1 depends on pywin32
    supervisor-win 4.0.3 depends on pywin32
    supervisor-win 4.0.2 depends on pywin32
    supervisor-win 4.0.1 depends on pywin32
    supervisor-win 4.0.0 depends on pywin32
```

`sys.platform` returns "darwin" on macOS, so the condition
`"win" in sys.platform` is evaluated to true and pip tries to install supervisor-win

Switch to `platform.system()` which makes it easier to differentiate Linux/Windows/Darwin