### PR TITLE
Exclude top level tests from packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     description="A centralized supervisor UI (web & CLI)",
     long_description=readme,
     long_description_content_type="text/markdown",
-    packages=find_packages(),
+    packages=find_packages(exclude=("tests", "tests.*")),
     package_data={
         "multivisor.server": ["dist/*", "dist/static/css/*", "dist/static/js/*"]
     },


### PR DESCRIPTION
The current multivisor package installs the "tests" directory
as global package. It should be excluded.