### PR TITLE
Bundle fonts Material Icons and Roboto

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,6 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <title>multivisor</title>
-    <link href='https://fonts.googleapis.com/css?family=Roboto:300,400,500,700|Material+Icons' rel="stylesheet">
   </head>
   <body>
     <div id="app"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,11 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@fontsource/roboto": {
+      "version": "5.2.9",
+      "resolved": "https://registry.npmjs.org/@fontsource/roboto/-/roboto-5.2.9.tgz",
+      "integrity": "sha512-ZTkyHiPk74B/aj8BZWbsxD5Yu+Lq+nR64eV4wirlrac2qXR7jYk2h6JlLYuOuoruTkGQWNw2fMuKNavw7/rg0w=="
+    },
     "accepts": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
@@ -6042,6 +6047,11 @@
       "requires": {
         "object-visit": "^1.0.0"
       }
+    },
+    "material-design-icons-iconfont": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/material-design-icons-iconfont/-/material-design-icons-iconfont-6.7.0.tgz",
+      "integrity": "sha512-lSj71DgVv20kO0kGbs42icDzbRot61gEDBLQACzkUuznRQBUYmbxzEkGU6dNBb5fRWHMaScYlAXX96HQ4/cJWA=="
     },
     "math-expression-evaluator": {
       "version": "1.2.17",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "build": "node build/build.js"
   },
   "dependencies": {
+    "@fontsource/roboto": "^5.2.9",
+    "material-design-icons-iconfont": "^6.7.0",
     "vue": "^2.5.22",
     "vue-router": "^3.0.2",
     "vuetify": "^1.4.4",

--- a/src/main.js
+++ b/src/main.js
@@ -1,3 +1,6 @@
+import '@fontsource/roboto'
+import 'material-design-icons-iconfont/dist/material-design-icons.css'
+
 import Vue from 'vue'
 import Vuetify from 'vuetify'
 import 'vuetify/dist/vuetify.min.css'
@@ -6,7 +9,9 @@ import App from '@/App'
 import store from '@/store'
 import router from '@/router'
 
-Vue.use(Vuetify)
+Vue.use(Vuetify, {
+  iconfont: 'md'
+})
 
 Vue.config.productionTip = false
 


### PR DESCRIPTION
Bundle fonts Material Icons and Roboto in order to avoid external HTTP requests.

GitHub: fix https://github.com/tiagocoutinho/multivisor/issues/9