### PR TITLE
Reconnect to supervisor after remote host restart

### DIFF
--- a/multivisor/multivisor.py
+++ b/multivisor/multivisor.py
@@ -78,6 +78,21 @@ class Supervisor(dict):
                 if delta < 10:
                     sleep(10 - delta)
                 last_retry = time.time()
+                self.reconnect()
+
+    def reconnect(self):
+        """Replace the client so the next attempt dials a fresh connection.
+
+        When the remote host reboots, the established connection dies
+        without a RST/FIN reaching us: TCP stays half-open forever and
+        zmq never re-dials, so every retry runs into the same dead pipe
+        and the supervisor stays offline until multivisor is restarted.
+        """
+        try:
+            self.server.close()
+        except Exception:
+            self.log.debug("error closing stale client", exc_info=True)
+        self.server = zerorpc.Client(self.address)
 
     def handle_event(self, event):
         name = event["eventname"]

--- a/multivisor/tests/test_multivisor.py
+++ b/multivisor/tests/test_multivisor.py
@@ -145,6 +145,17 @@ def test_use_authentication(multivisor_instance):
 
 
 @pytest.mark.usefixtures("supervisor_test001")
+def test_reconnect_replaces_client(multivisor_instance):
+    supervisor = multivisor_instance.get_supervisor("test001")
+    stale = supervisor.server
+    supervisor.reconnect()
+    assert supervisor.server is not stale
+    info = supervisor.read_info()
+    assert info["running"]
+    assert len(info["processes"]) == 10
+
+
+@pytest.mark.usefixtures("supervisor_test001")
 def test_stop_process(multivisor_instance):
     multivisor_instance.refresh()  # processes are empty before calling this
     uid = "test001:PLC:wcid00d"


### PR DESCRIPTION
## Problem

When a machine running a remote supervisord reboots, the multivisor web instance watching it never recovers on its own — the host stays offline in the UI until multivisor itself is restarted, even though the remote answers fresh clients fine.

Mechanism: the reboot kills the peer without a FIN/RST reaching the client, so the established TCP connection stays half-open on the multivisor side. zmq only re-dials on a socket error, which never comes; `Supervisor.run()` catches `LostRemote`/`TimeoutExpired` and retries, but `self.server` was created once in `__init__`, so every retry runs into the same dead pipe. The observable signature is `Lost remote / (re)initializing...` cycling every ~15s forever, with no new outbound connection ever opened.

Note a plain local kill/restart of supervisord does **not** reproduce this: the kernel sends RST, zmq reconnects, and the current code recovers — which is probably why this survived so long. It needs the peer to vanish silently (reboot, power loss, packet filter).

## Fix

Recreate the `zerorpc.Client` at the end of each `run()` cycle (`Supervisor.reconnect()`): every (re)initialization dials a fresh connection, so the first retry after the remote returns succeeds. The stale client is closed to release its socket.

## Repro

Two supervisords won't show it (RST, see above), so I emulated the half-open socket with a small TCP proxy between the client and a local supervisord: on "reboot" it holds the client-side connection open but stops relaying (no RST), restarts supervisord behind it, and forwards new connections to the new instance.

- Before: client cycles `Lost remote / (re)initializing` indefinitely (>2 min observed), proxy sees zero new connections, host stays `running=False`.
- After: one `Lost remote`, one reinit cycle, host back online with the new supervisord PID (~15s), proxy sees the fresh dial.

## Tests

`test_reconnect_replaces_client` added in the existing live-supervisord style; `multivisor/tests` and `multivisor/server/tests` both pass (9+9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016sPXEiewgoW2SpSg7pPXiH