### PR TITLE
Frontend fix search escape keydown not resetting the filter

### DIFF
--- a/src/components/ToolBar.vue
+++ b/src/components/ToolBar.vue
@@ -44,7 +44,7 @@
           single-line
           clearable
           autofocus
-          @keydown.esc="showSearch = false"
+          @keydown.esc="search = ''; showSearch = false"
           @click:clear="showSearch = false"
           @blur="search && search.length ? showSearch : showSearch = false"
           class="search-input"


### PR DESCRIPTION
Hitting the escape key while the search input has focus does close the search input but do not reset the filter.